### PR TITLE
Add support for configuring ambiguous character width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added functionality to configure how characters in the Ambiguous category are treated: as either narrow (half-width) or wide (full-width).
+  - cjkfmt follows the East Asian Width property as specified in Unicode Annex #11, using the [`unicode-width`](https://crates.io/crates/unicode-width) crate.
+
 - Functionality to configure spacing rules.
   - `spacing.alphabets` controls how to handle spaces between full-width and half-width alphabets.
     Possible values are `require`, `prohibit`, and `ignore`.

--- a/src/check.rs
+++ b/src/check.rs
@@ -12,7 +12,10 @@ pub(crate) fn check_one_file(
     filename: Option<&str>,
     content: &str,
 ) -> Result<Vec<Diagnostic>, anyhow::Error> {
-    let breaker = LineBreaker::builder().max_width(config.max_width).build()?;
+    let breaker = LineBreaker::builder()
+        .ambiguous_width(config.ambiguous_width)
+        .max_width(config.max_width)
+        .build()?;
 
     let mut diagnostics = Vec::new();
     for (line_index, line) in content.lines_inclusive().enumerate() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,10 @@ use crate::args::CliArgs;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    /// Maximum line width to allow. (default: 80)
+    /// How to treat width of characters in the Ambiguous category according to Unicode Standard Annex #11.
+    pub ambiguous_width: AmbiguousWidth,
+
+    /// Maximum line width to allow. (dfault: 80)
     pub max_width: u32,
 
     /// Rules for handling spaces between full-width and half-width characters.
@@ -52,6 +55,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
+            ambiguous_width: AmbiguousWidth::Wide,
             max_width: 80,
             spacing: Default::default(),
         }
@@ -94,4 +98,16 @@ impl Default for SpacingConfig {
             punctuation_as_fullwidth: false,
         }
     }
+}
+
+/// How to treat width of characters in the Ambiguous category according to Unicode Standard Annex #11.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AmbiguousWidth {
+    /// Treat characters in the Ambiguous category as 1.
+    #[serde(alias = "Halfwidth")]
+    Narrow,
+
+    /// Treat characters in the Ambiguous category as 2.
+    #[serde(alias = "Fullwidth")]
+    Wide,
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -9,7 +9,10 @@ pub(crate) fn format_one_file<W: std::io::Write>(
     config: &Config,
     content: &str,
 ) -> Result<(), anyhow::Error> {
-    let line_breaker = LineBreaker::builder().max_width(config.max_width).build()?;
+    let line_breaker = LineBreaker::builder()
+        .ambiguous_width(config.ambiguous_width)
+        .max_width(config.max_width)
+        .build()?;
 
     // Iterate over each line in the input content, including line endings
     for line in content.lines_inclusive() {

--- a/src/line_break.rs
+++ b/src/line_break.rs
@@ -3,7 +3,7 @@ use unicode_linebreak::{BreakClass, break_property};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use crate::_log::test_log;
+use crate::{_log::test_log, config::AmbiguousWidth};
 
 /// Grapheme clusters prohibited at the start of a line.
 pub const PROHIBITED_START: &str = ")]｝〕〉》」』】〙〗〟'\"｠»\
@@ -44,6 +44,7 @@ pub enum BreakPoint {
 /// Use [`LineBreaker::builder`] to create a new instance of [`LineBreaker`].
 #[derive(Debug)]
 pub struct LineBreaker {
+    ambiguous_width: AmbiguousWidth,
     max_width: u32,
     prohibited_start: Vec<String>,
     prohibited_end: Vec<String>,
@@ -55,6 +56,15 @@ pub struct LineBreakerBuilder {
 }
 
 impl LineBreakerBuilder {
+    /// Sets how to treat width of characters in the Ambiguous category.
+    ///
+    /// The width is measured in terms of fullwidth characters.
+    /// For example, the width of "あ" is 2, and the width of "a" is 1.
+    pub fn ambiguous_width(mut self, ambiguous_width: AmbiguousWidth) -> Self {
+        self.line_breaker.ambiguous_width = ambiguous_width;
+        self
+    }
+
     /// Sets the maximum width of a line.
     ///
     /// The width is measured in terms of fullwidth characters.
@@ -106,6 +116,7 @@ impl LineBreaker {
     pub fn builder() -> LineBreakerBuilder {
         LineBreakerBuilder {
             line_breaker: LineBreaker {
+                ambiguous_width: AmbiguousWidth::Wide,
                 max_width: 80,
                 prohibited_start: Vec::new(),
                 prohibited_end: Vec::new(),
@@ -113,6 +124,12 @@ impl LineBreaker {
         }
         .prohibited_start(PROHIBITED_START)
         .prohibited_end(PROHIBITED_END)
+    }
+
+    /// Returns how to treat width of characters in the Ambiguous category.
+    #[allow(dead_code)]
+    pub fn ambiguous_width(&self) -> AmbiguousWidth {
+        self.ambiguous_width
     }
 
     /// Returns the maximum width of a line.
@@ -152,9 +169,18 @@ impl LineBreaker {
             }
 
             // Test whether rendering this grapheme cluster will exceed the limit or not
-            let width = grapheme.width_cjk() as u32;
+            let width = if self.ambiguous_width == AmbiguousWidth::Narrow {
+                grapheme.width()
+            } else {
+                grapheme.width_cjk()
+            } as u32;
             if self.max_width < acc_width + width {
-                test_log!("  {i:02} {:?} !!", grapheme);
+                test_log!(
+                    "  {i:02} {:?} # max_width < acc_width + width ({} < {})",
+                    grapheme,
+                    self.max_width,
+                    acc_width + width
+                );
                 if let Some(nbytes_seek_back) =
                     self.num_bytes_to_seek_back(graphemes.as_slice(), grapheme)
                 {
@@ -172,7 +198,10 @@ impl LineBreaker {
             }
 
             // Go to next grapheme cluster
-            test_log!("  {i:02} {:?}", grapheme);
+            test_log!(
+                "  {i:03} {grapheme:?} (acc_width+{width}: {})",
+                acc_width + width
+            );
             graphemes.push(grapheme);
             acc_width += width;
         }
@@ -279,6 +308,45 @@ mod test {
         #[case] expected: bool,
     ) {
         assert_eq!(is_breakable(preceding, following), expected);
+    }
+
+    #[test]
+    fn test_ambiguous_width() {
+        for ambiguous_width in [AmbiguousWidth::Wide, AmbiguousWidth::Narrow] {
+            let line_breaker = LineBreaker::builder()
+                .ambiguous_width(ambiguous_width)
+                .max_width(2)
+                .build()
+                .unwrap();
+
+            assert_eq!(
+                line_breaker.next_line_break("1a1a\n"),
+                BreakPoint::WrapPoint {
+                    overflow_pos: 2,
+                    adjustment: 0
+                },
+            );
+            assert_eq!(
+                line_breaker.next_line_break("あa1a\n"),
+                BreakPoint::WrapPoint {
+                    overflow_pos: 3,
+                    adjustment: 0
+                },
+            );
+            assert_eq!(
+                line_breaker.next_line_break("※a1a\n"),
+                BreakPoint::WrapPoint {
+                    overflow_pos: match ambiguous_width {
+                        AmbiguousWidth::Narrow => 4,
+                        AmbiguousWidth::Wide => 3,
+                    },
+                    adjustment: 0
+                },
+            );
+        }
+        assert!(LineBreaker::builder().max_width(1).build().is_err());
+        assert!(LineBreaker::builder().max_width(2).build().is_ok());
+        assert!(LineBreaker::builder().max_width(3).build().is_ok());
     }
 
     #[test]

--- a/test_cases/format/ambiguous-width-narrow.json
+++ b/test_cases/format/ambiguous-width-narrow.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "ambiguous_width": "Narrow",
+    "max_width": 17
+  },
+  "input": "※East Asian WidthプロパティがAmbiguous",
+  "output": "※East Asian Width\nプロパティが\nAmbiguous"
+}

--- a/test_cases/format/ambiguous-width-wide.json
+++ b/test_cases/format/ambiguous-width-wide.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "ambiguous_width": "Wide",
+    "max_width": 17
+  },
+  "input": "※East Asian WidthプロパティがAmbiguous",
+  "output": "※East Asian \nWidthプロパティが\nAmbiguous"
+}


### PR DESCRIPTION
Introduce functionality to configure the treatment of ambiguous characters as either narrow or wide, following Unicode Standard Annex #11.