### PR TITLE
Expose configuration settings as command-line flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Possible values are `require`, `prohibit`, and `ignore`.
   - `spacing.digits` controls how to handle spaces between full-width and half-width digits.
     Possible values are the same as for alphabets.
-  - `spacing.punctuation_as_fullwidth` controls whether to treat full-width punctuation as full-width
-    characters or not.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added the CLI options for config override: `--ambiguous-width`, `--spacing-alphabets`,
+  `--spacing-digits`, and `--spacing-punctuation-as-fullwidth`.
+
 ### Miscellaneous
 
 - Refactored the space problem checker to work on the concrete syntax tree (CST) rather than

--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ The configuration file is searched for in the current directory and, if not foun
 
 Currently, the following configuration options are available:
 
-| Option                             | Description                                                           | Default  |
-| ---------------------------------- | --------------------------------------------------------------------- | -------- |
-| `ambiguous_width`                  | Width of Unicode Ambiguous characters (`narrow` or `wide`)            | `wide`   |
-| `max_width`                        | Maximum line width to allow                                           | 80       |
-| `spacing.alphabets`                | Require, prohibit, or ignore spaces around full-/half-width alphabets | `ignore` |
-| `spacing.digits`                   | Require, prohibit, or ignore spaces around full-/half-width digits    | `ignore` |
-| `spacing.punctuation_as_fullwidth` | Treat full-width punctuation as full-width (`true` or `false`)        | `false`  |
+| Option              | Description                                                           | Default  |
+| ------------------- | --------------------------------------------------------------------- | -------- |
+| `ambiguous_width`   | Width of Unicode Ambiguous characters (`narrow` or `wide`)            | `wide`   |
+| `max_width`         | Maximum line width to allow                                           | 80       |
+| `spacing.alphabets` | Require, prohibit, or ignore spaces around full-/half-width alphabets | `ignore` |
+| `spacing.digits`    | Require, prohibit, or ignore spaces around full-/half-width digits    | `ignore` |
 
 Depending on the configuration source, the option names are formatted slightly differently:
 
@@ -50,8 +49,7 @@ Depending on the configuration source, the option names are formatted slightly d
 - Command line options
   - Use hyphens between words, and put two dashes before the option name.
     Examples: `--max-width 100`, `--ambiguous-width narrow`,
-    `--spacing-alphabets require`, `--spacing-digits prohibit`, and
-    `--spacing-punctuation-as-fullwidth true`
+    `--spacing-alphabets require`, and `--spacing-digits prohibit`
 
 ### Example Configuration File
 
@@ -63,14 +61,10 @@ Below is an example configuration file `.cjkfmt.json`.
   "max_width": 100,
   "spacing": {
     "alphabets": "require",
-    "digits": "ignore",
-    "punctuation_as_fullwidth": false
+    "digits": "ignore"
   }
 }
 ```
-
-The `spacing.punctuation_as_fullwidth` setting is accepted for configuration
-compatibility, but is not currently used by the formatter.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ The configuration file is searched for in the current directory and, if not foun
 
 Currently, the following configuration options are available:
 
-| Option      | Description                 | Default |
-| ----------- | --------------------------- | ------- |
-| `max_width` | Maximum line width to allow | 80      |
+| Option                             | Description                                                           | Default  |
+| ---------------------------------- | --------------------------------------------------------------------- | -------- |
+| `ambiguous_width`                  | Width of Unicode Ambiguous characters (`narrow` or `wide`)            | `wide`   |
+| `max_width`                        | Maximum line width to allow                                           | 80       |
+| `spacing.alphabets`                | Require, prohibit, or ignore spaces around full-/half-width alphabets | `ignore` |
+| `spacing.digits`                   | Require, prohibit, or ignore spaces around full-/half-width digits    | `ignore` |
+| `spacing.punctuation_as_fullwidth` | Treat full-width punctuation as full-width (`true` or `false`)        | `false`  |
 
 Depending on the configuration source, the option names are formatted slightly differently:
 
@@ -45,7 +49,9 @@ Depending on the configuration source, the option names are formatted slightly d
     Example: `CJKFMT_MAX_WIDTH`
 - Command line options
   - Use hyphens between words, and put two dashes before the option name.
-    Example: `--max-width 100`
+    Examples: `--max-width 100`, `--ambiguous-width narrow`,
+    `--spacing-alphabets require`, `--spacing-digits prohibit`, and
+    `--spacing-punctuation-as-fullwidth true`
 
 ### Example Configuration File
 
@@ -53,9 +59,18 @@ Below is an example configuration file `.cjkfmt.json`.
 
 ```json
 {
-  "max_width": 100
+  "ambiguous_width": "wide",
+  "max_width": 100,
+  "spacing": {
+    "alphabets": "require",
+    "digits": "ignore",
+    "punctuation_as_fullwidth": false
+  }
 }
 ```
+
+The `spacing.punctuation_as_fullwidth` setting is accepted for configuration
+compatibility, but is not currently used by the formatter.
 
 ## License
 

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -3,9 +3,11 @@ use std::{collections::BTreeMap, path::PathBuf};
 use clap::{Parser, Subcommand, ValueEnum};
 use figment::{
     Profile, Provider,
-    value::{Dict, Map},
+    value::{Dict, Map, Value},
 };
 use serde::{Deserialize, Serialize};
+
+use crate::config::{AmbiguousWidth, SpacingRule};
 
 #[derive(ValueEnum, Debug, Clone, Deserialize, Serialize)]
 pub enum ColorOutputMode {
@@ -31,6 +33,22 @@ pub struct CliArgs {
     #[arg(short, long)]
     pub max_width: Option<u32>,
 
+    /// How to treat characters in Unicode's Ambiguous category: `narrow` or `wide`. [default: wide]
+    #[arg(long, value_enum)]
+    pub ambiguous_width: Option<AmbiguousWidth>,
+
+    /// Require, prohibit, or ignore spaces between full-width and half-width alphabets. [default: ignore]
+    #[arg(long, value_enum)]
+    pub spacing_alphabets: Option<SpacingRule>,
+
+    /// Require, prohibit, or ignore spaces between full-width and half-width digits. [default: ignore]
+    #[arg(long, value_enum)]
+    pub spacing_digits: Option<SpacingRule>,
+
+    /// Whether full-width punctuation is treated as full-width (`true` or `false`). [default: false]
+    #[arg(long, action = clap::ArgAction::Set)]
+    pub spacing_punctuation_as_fullwidth: Option<bool>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -44,10 +62,36 @@ impl Provider for CliArgs {
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
         let mut dict = BTreeMap::new();
         if let Some(max_width) = self.max_width {
+            dict.insert("max_width".to_string(), Value::from(max_width));
+        }
+        if let Some(ambiguous_width) = self.ambiguous_width {
             dict.insert(
-                "max_width".to_string(),
-                figment::value::Value::from(max_width),
+                "ambiguous_width".to_string(),
+                Value::from(format!("{ambiguous_width:?}")),
             );
+        }
+
+        let mut spacing = BTreeMap::new();
+        if let Some(alphabets) = self.spacing_alphabets {
+            spacing.insert(
+                "alphabets".to_string(),
+                Value::from(format!("{alphabets:?}").to_ascii_lowercase()),
+            );
+        }
+        if let Some(digits) = self.spacing_digits {
+            spacing.insert(
+                "digits".to_string(),
+                Value::from(format!("{digits:?}").to_ascii_lowercase()),
+            );
+        }
+        if let Some(punctuation_as_fullwidth) = self.spacing_punctuation_as_fullwidth {
+            spacing.insert(
+                "punctuation_as_fullwidth".to_string(),
+                Value::from(punctuation_as_fullwidth),
+            );
+        }
+        if !spacing.is_empty() {
+            dict.insert("spacing".to_string(), Value::from(spacing));
         }
 
         let mut map = BTreeMap::new();

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -56,6 +56,8 @@ impl Provider for CliArgs {
     }
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        // Note: `to_ascii_lowercase` does not convert the string into snake_case so we should use a
+        // new crate and use it for case-conversion (e.g., `heck`)
         let mut dict = BTreeMap::new();
         if let Some(max_width) = self.max_width {
             dict.insert("max_width".to_string(), Value::from(max_width));
@@ -63,7 +65,7 @@ impl Provider for CliArgs {
         if let Some(ambiguous_width) = self.ambiguous_width {
             dict.insert(
                 "ambiguous_width".to_string(),
-                Value::from(format!("{ambiguous_width:?}")),
+                Value::from(format!("{ambiguous_width:?}").to_ascii_lowercase()),
             );
         }
 

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -91,6 +91,79 @@ impl Provider for CliArgs {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use figment::{Figment, providers::Serialized};
+    use rstest::rstest;
+
+    use super::*;
+    use crate::config::Config;
+
+    fn config_from(arguments: impl IntoIterator<Item = &'static str>) -> Config {
+        let args =
+            CliArgs::try_parse_from(arguments).expect("the command-line arguments should parse");
+
+        Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(&args)
+            .extract()
+            .expect("CLI values should deserialize as configuration")
+    }
+
+    #[rstest]
+    #[case("narrow", AmbiguousWidth::Narrow)]
+    #[case("wide", AmbiguousWidth::Wide)]
+    fn ambiguous_width_flag_maps_each_clap_value_to_config(
+        #[case] value: &'static str,
+        #[case] expected: AmbiguousWidth,
+    ) {
+        let config = config_from(["cjkfmt", "--ambiguous-width", value, "format"]);
+
+        assert_eq!(config.ambiguous_width, expected);
+    }
+
+    #[rstest]
+    #[case("require", SpacingRule::Require)]
+    #[case("prohibit", SpacingRule::Prohibit)]
+    #[case("ignore", SpacingRule::Ignore)]
+    fn spacing_alphabets_flag_maps_each_clap_value_to_config(
+        #[case] value: &'static str,
+        #[case] expected: SpacingRule,
+    ) {
+        let config = config_from(["cjkfmt", "--spacing-alphabets", value, "format"]);
+
+        assert_eq!(config.spacing.alphabets, expected);
+    }
+
+    #[rstest]
+    #[case("require", SpacingRule::Require)]
+    #[case("prohibit", SpacingRule::Prohibit)]
+    #[case("ignore", SpacingRule::Ignore)]
+    fn spacing_digits_flag_maps_each_clap_value_to_config(
+        #[case] value: &'static str,
+        #[case] expected: SpacingRule,
+    ) {
+        let config = config_from(["cjkfmt", "--spacing-digits", value, "format"]);
+
+        assert_eq!(config.spacing.digits, expected);
+    }
+
+    #[test]
+    fn spacing_flags_are_merged_as_independent_nested_config_values() {
+        let config = config_from([
+            "cjkfmt",
+            "--spacing-alphabets",
+            "require",
+            "--spacing-digits",
+            "prohibit",
+            "format",
+        ]);
+
+        assert_eq!(config.spacing.alphabets, SpacingRule::Require);
+        assert_eq!(config.spacing.digits, SpacingRule::Prohibit);
+    }
+}
+
 #[derive(Subcommand, Debug, Deserialize, Serialize)]
 pub enum Commands {
     /// Format files according to CJK text formatting rules.

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -69,16 +69,10 @@ impl Provider for CliArgs {
 
         let mut spacing = BTreeMap::new();
         if let Some(alphabets) = self.spacing_alphabets {
-            spacing.insert(
-                "alphabets".to_string(),
-                Value::serialize(alphabets)?,
-            );
+            spacing.insert("alphabets".to_string(), Value::serialize(alphabets)?);
         }
         if let Some(digits) = self.spacing_digits {
-            spacing.insert(
-                "digits".to_string(),
-                Value::serialize(digits)?,
-            );
+            spacing.insert("digits".to_string(), Value::serialize(digits)?);
         }
         if !spacing.is_empty() {
             dict.insert("spacing".to_string(), Value::from(spacing));

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -45,10 +45,6 @@ pub struct CliArgs {
     #[arg(long, value_enum)]
     pub spacing_digits: Option<SpacingRule>,
 
-    /// Whether full-width punctuation is treated as full-width (`true` or `false`). [default: false]
-    #[arg(long, action = clap::ArgAction::Set)]
-    pub spacing_punctuation_as_fullwidth: Option<bool>,
-
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -82,12 +78,6 @@ impl Provider for CliArgs {
             spacing.insert(
                 "digits".to_string(),
                 Value::from(format!("{digits:?}").to_ascii_lowercase()),
-            );
-        }
-        if let Some(punctuation_as_fullwidth) = self.spacing_punctuation_as_fullwidth {
-            spacing.insert(
-                "punctuation_as_fullwidth".to_string(),
-                Value::from(punctuation_as_fullwidth),
             );
         }
         if !spacing.is_empty() {

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -110,6 +110,13 @@ mod tests {
             .expect("CLI values should deserialize as configuration")
     }
 
+    #[test]
+    fn max_width_flag_maps_clap_value_to_config() {
+        let config = config_from(["cjkfmt", "--max-width", "42", "format"]);
+
+        assert_eq!(config.max_width, 42);
+    }
+
     #[rstest]
     #[case("narrow", AmbiguousWidth::Narrow)]
     #[case("wide", AmbiguousWidth::Wide)]

--- a/cjkfmt-cli/src/cli/args.rs
+++ b/cjkfmt-cli/src/cli/args.rs
@@ -56,8 +56,6 @@ impl Provider for CliArgs {
     }
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
-        // Note: `to_ascii_lowercase` does not convert the string into snake_case so we should use a
-        // new crate and use it for case-conversion (e.g., `heck`)
         let mut dict = BTreeMap::new();
         if let Some(max_width) = self.max_width {
             dict.insert("max_width".to_string(), Value::from(max_width));
@@ -65,7 +63,7 @@ impl Provider for CliArgs {
         if let Some(ambiguous_width) = self.ambiguous_width {
             dict.insert(
                 "ambiguous_width".to_string(),
-                Value::from(format!("{ambiguous_width:?}").to_ascii_lowercase()),
+                Value::serialize(ambiguous_width)?,
             );
         }
 
@@ -73,13 +71,13 @@ impl Provider for CliArgs {
         if let Some(alphabets) = self.spacing_alphabets {
             spacing.insert(
                 "alphabets".to_string(),
-                Value::from(format!("{alphabets:?}").to_ascii_lowercase()),
+                Value::serialize(alphabets)?,
             );
         }
         if let Some(digits) = self.spacing_digits {
             spacing.insert(
                 "digits".to_string(),
-                Value::from(format!("{digits:?}").to_ascii_lowercase()),
+                Value::serialize(digits)?,
             );
         }
         if !spacing.is_empty() {

--- a/cjkfmt-cli/src/config.rs
+++ b/cjkfmt-cli/src/config.rs
@@ -106,6 +106,7 @@ mod tests {
         Figment,
         providers::{Format, Json, Serialized},
     };
+    use rstest::rstest;
     use serde_json::json;
 
     use super::*;
@@ -131,7 +132,7 @@ mod tests {
             .merge(Json::string(
                 r#"{
                     "max_width": 90,
-                    "ambiguous_width": "Narrow",
+                    "ambiguous_width": "narrow",
                     "spacing": { "alphabets": "require", "digits": "require" }
                 }"#,
             ))
@@ -157,16 +158,81 @@ mod tests {
             "the CLI should override the environment"
         );
     }
+
+    #[rstest]
+    // "snake_case" is the documented, canonical form (ADR-0001).
+    #[case("narrow", Some(AmbiguousWidth::Narrow))]
+    #[case("wide", Some(AmbiguousWidth::Wide))]
+    #[case("halfwidth", Some(AmbiguousWidth::Narrow))]
+    #[case("fullwidth", Some(AmbiguousWidth::Wide))]
+    #[case("Narrow", None)]
+    #[case("Wide", None)]
+    #[case("Halfwidth", None)]
+    #[case("Fullwidth", None)]
+    fn ambiguous_width_accepts_only_snake_case_value(
+        #[case] value: &str,
+        #[case] expected: Option<AmbiguousWidth>,
+    ) {
+        let result: Result<Config, _> = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Json::string(&format!(
+                r#"{{ "ambiguous_width": "{value}" }}"#
+            )))
+            .extract();
+
+        match expected {
+            Some(expected) => assert_eq!(
+                result
+                    .expect("the documented snake_case value should deserialize")
+                    .ambiguous_width,
+                expected
+            ),
+            None => assert!(result.is_err(), "non-snake_case value should be rejected"),
+        }
+    }
+
+    #[rstest]
+    // "snake_case" is the documented, canonical form (ADR-0001).
+    #[case("require", Some(SpacingRule::Require))]
+    #[case("prohibit", Some(SpacingRule::Prohibit))]
+    #[case("ignore", Some(SpacingRule::Ignore))]
+    #[case("Require", None)]
+    #[case("Prohibit", None)]
+    #[case("Ignore", None)]
+    fn spacing_rule_accepts_only_snake_case_value(
+        #[case] value: &str,
+        #[case] expected: Option<SpacingRule>,
+    ) {
+        let result: Result<Config, _> = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Json::string(&format!(
+                r#"{{ "spacing": {{ "alphabets": "{value}" }} }}"#
+            )))
+            .extract();
+
+        match expected {
+            Some(expected) => assert_eq!(
+                result
+                    .expect("the documented snake_case value should deserialize")
+                    .spacing
+                    .alphabets,
+                expected
+            ),
+            None => assert!(result.is_err(), "non-snake_case value should be rejected"),
+        }
+    }
 }
 
 /// How to treat width of characters in the Ambiguous category according to Unicode Standard Annex #11.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
 pub enum AmbiguousWidth {
     /// Treat characters in the Ambiguous category as 1.
-    #[serde(alias = "Halfwidth")]
+    // `halfwidth` is kept as a friendlier synonym some users may reach for.
+    #[serde(alias = "halfwidth")]
     Narrow,
 
     /// Treat characters in the Ambiguous category as 2.
-    #[serde(alias = "Fullwidth")]
+    #[serde(alias = "fullwidth")]
     Wide,
 }

--- a/cjkfmt-cli/src/config.rs
+++ b/cjkfmt-cli/src/config.rs
@@ -1,5 +1,6 @@
 use std::{env, path::PathBuf};
 
+use clap::ValueEnum;
 use figment::{
     Figment,
     providers::{Env, Format, Json, Serialized},
@@ -63,7 +64,7 @@ impl Default for Config {
 }
 
 /// Rules for handling spaces between full-width and half-width characters.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum SpacingRule {
     /// Require a space between full-width and half-width characters.
@@ -101,7 +102,7 @@ impl Default for SpacingConfig {
 }
 
 /// How to treat width of characters in the Ambiguous category according to Unicode Standard Annex #11.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 pub enum AmbiguousWidth {
     /// Treat characters in the Ambiguous category as 1.
     #[serde(alias = "Halfwidth")]

--- a/cjkfmt-cli/src/config.rs
+++ b/cjkfmt-cli/src/config.rs
@@ -86,9 +86,8 @@ pub struct SpacingConfig {
 
     /// How to handle spaces between full-width and half-width digits.
     pub digits: SpacingRule,
-
-    /// Whether to treat full-width punctuation as full-width characters or not.
-    pub punctuation_as_fullwidth: bool, // TODO: Use punctuation_as_fullwidth setting
+    // /// Whether to treat full-width punctuation as full-width characters or not.
+    // pub punctuation_as_fullwidth: bool, // TODO: Implement this option
 }
 
 impl Default for SpacingConfig {
@@ -96,7 +95,6 @@ impl Default for SpacingConfig {
         SpacingConfig {
             alphabets: SpacingRule::Ignore,
             digits: SpacingRule::Ignore,
-            punctuation_as_fullwidth: false,
         }
     }
 }

--- a/cjkfmt-cli/src/config.rs
+++ b/cjkfmt-cli/src/config.rs
@@ -99,6 +99,63 @@ impl Default for SpacingConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use figment::{
+        Figment,
+        providers::{Format, Json, Serialized},
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse_args(arguments: impl IntoIterator<Item = &'static str>) -> CliArgs {
+        CliArgs::try_parse_from(arguments).expect("the command-line arguments should parse")
+    }
+
+    #[test]
+    fn configuration_sources_are_applied_in_default_file_env_cli_order() {
+        let args = parse_args(["cjkfmt", "--spacing-digits", "ignore", "format"]);
+        let environment = json!({
+            "spacing": {
+                "alphabets": "prohibit",
+                "digits": "prohibit",
+            },
+        });
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Json::string(
+                r#"{
+                    "max_width": 90,
+                    "ambiguous_width": "Narrow",
+                    "spacing": { "alphabets": "require", "digits": "require" }
+                }"#,
+            ))
+            .merge(Serialized::defaults(environment))
+            .merge(&args)
+            .extract()
+            .expect("all configuration sources should deserialize");
+
+        assert_eq!(config.max_width, 90, "the file should override the default");
+        assert_eq!(
+            config.ambiguous_width,
+            AmbiguousWidth::Narrow,
+            "the file should override the default"
+        );
+        assert_eq!(
+            config.spacing.alphabets,
+            SpacingRule::Prohibit,
+            "the environment should override the file"
+        );
+        assert_eq!(
+            config.spacing.digits,
+            SpacingRule::Ignore,
+            "the CLI should override the environment"
+        );
+    }
+}
+
 /// How to treat width of characters in the Ambiguous category according to Unicode Standard Annex #11.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 pub enum AmbiguousWidth {

--- a/cjkfmt-cli/src/config.rs
+++ b/cjkfmt-cli/src/config.rs
@@ -115,8 +115,11 @@ mod tests {
     }
 
     #[test]
+    // Re-implements `Config::from_cli_args`'s merge chain rather than calling it, since
+    // that function touches real files and env vars. Keep the two in sync manually.
     fn configuration_sources_are_applied_in_default_file_env_cli_order() {
         let args = parse_args(["cjkfmt", "--spacing-digits", "ignore", "format"]);
+        // Stands in for the env layer's position in the chain; not real `Env::prefixed` parsing.
         let environment = json!({
             "spacing": {
                 "alphabets": "prohibit",

--- a/cjkfmt-cli/test_cases/format/ambiguous-width-narrow.json
+++ b/cjkfmt-cli/test_cases/format/ambiguous-width-narrow.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "ambiguous_width": "Narrow",
+    "ambiguous_width": "narrow",
     "max_width": 17
   },
   "input": "※East Asian WidthプロパティがAmbiguous",

--- a/cjkfmt-cli/test_cases/format/ambiguous-width-wide.json
+++ b/cjkfmt-cli/test_cases/format/ambiguous-width-wide.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "ambiguous_width": "Wide",
+    "ambiguous_width": "wide",
     "max_width": 17
   },
   "input": "※East Asian WidthプロパティがAmbiguous",

--- a/docs/adr/0001-config-values-use-snake-case.md
+++ b/docs/adr/0001-config-values-use-snake-case.md
@@ -1,0 +1,31 @@
+# Config values are serialized in snake_case
+
+Status: accepted
+
+cjkfmt's configuration file keys are already snake_case, matching the Rust
+struct field names they map to (e.g. `ambiguous_width`, `spacing.alphabets`).
+We serialize/deserialize the _values_ of config enums the same way — using
+`#[serde(rename_all = "snake_case")]` — rather than leaving them as their Rust
+variant names (PascalCase) or switching to kebab-case, so that every config
+file uses one consistent word-separator convention throughout, for both keys
+and values.
+
+## Considered Options
+
+- **PascalCase (Rust variant names as-is).** Rejected: it leaks an
+  implementation detail (Rust's own naming convention for enum variants)
+  into the config file, and mismatches the snake_case keys sitting right
+  next to it in the same document.
+- **kebab-case.** Common among CLI tools' config files, but rejected here:
+  config keys are already snake_case for free (they're just the Rust field
+  names), so giving values the same treatment via `rename_all` costs
+  nothing extra. kebab-case would require explicit conversion everywhere
+  and would mix two different separator styles in one file.
+
+---
+
+Note: this ADR was recorded retrospectively on 2026-08-12. The convention
+itself originates from `af843aa` ("feat: make spacing rules configurable",
+2025-07-13), where `SpacingRule` first adopted
+`#[serde(rename_all = "snake_case")]`. It should have been applied
+consistently to every config enum added from that point onward.


### PR DESCRIPTION
Add CLI overrides for:

- `--ambiguous-width`
- `--spacing-alphabets`
- `--spacing-digits`
- ~~`--spacing-punctuation-as-fullwidth`~~

Preserve existing configuration precedence and document the defaults.

Note: `--spacing-punctuation-as-fullwidth` existed as no-op option meant to be a future implementation stub. Since it's no-op, I decided to remove it at the same time.