### PR TITLE
Format spacing between half-width and full-width characters

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -3,3 +3,4 @@ default: true
 line-length:
   line_length: 100
   stern: true
+  tables: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `cjkfmt format` now applies configured CJK/ASCII spacing rules to Markdown prose.
 - Added the CLI options for config override: `--ambiguous-width`, `--spacing-alphabets`,
   `--spacing-digits`, and `--spacing-punctuation-as-fullwidth`.
 
 ### Fixed
 
-- Fixed spacing diagnostic columns for inline Markdown content that begins after the start of a line.
+- Fixed spacing diagnostic columns for inline Markdown content that begins after the start of a
+  line.
 
 ### Miscellaneous
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "tempfile",
  "test-generator",
  "tree-sitter",
  "unicode-general-category",
@@ -220,6 +221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +295,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -489,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +619,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2 1.0.106",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
@@ -810,6 +840,19 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Depending on the configuration source, the option names are formatted slightly d
 
 The `format` command applies the spacing rules to Markdown prose, including visible text inside
 emphasis and links. Code spans, fenced code blocks, URLs, HTML, and other non-prose inline content
-are left unchanged.
+are left unchanged. For the implementation-level character classification and the difference between
+`check` and `format`, see [the spacing implementation notes](docs/design/spacing.md).
 
 Below is an example configuration file `.cjkfmt.json`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ## Configuration
 
-cjkfmt can be configured in several ways, with configuration options applied in the following order of precedence (highest to lowest):
+cjkfmt can be configured in several ways, with configuration options applied in the following order
+of precedence (highest to lowest):
 
 1. Command line options
 2. Environment variables prefixed with `CJKFMT_`
@@ -24,7 +25,8 @@ cjkfmt can be configured in several ways, with configuration options applied in 
    (`XDG_CONFIG_HOME` if set, otherwise `$HOME`)
 5. Default values
 
-The configuration file is searched for in the current directory and, if not found, in each parent directory up to the root. Only the first file found will be used.
+The configuration file is searched for in the current directory and, if not found, in each parent
+directory up to the root. Only the first file found will be used.
 
 ### Configuration Options
 
@@ -52,6 +54,10 @@ Depending on the configuration source, the option names are formatted slightly d
     `--spacing-alphabets require`, and `--spacing-digits prohibit`
 
 ### Example Configuration File
+
+The `format` command applies the spacing rules to Markdown prose, including visible text inside
+emphasis and links. Code spans, fenced code blocks, URLs, HTML, and other non-prose inline content
+are left unchanged.
 
 Below is an example configuration file `.cjkfmt.json`.
 

--- a/cjkfmt-cli/Cargo.toml
+++ b/cjkfmt-cli/Cargo.toml
@@ -31,3 +31,4 @@ regex = "1.12.3"
 rstest.workspace = true
 serde_json = "1.0.149"
 test-generator = "0.3.1"
+tempfile = "3.23.0"

--- a/cjkfmt-cli/src/check.rs
+++ b/cjkfmt-cli/src/check.rs
@@ -117,4 +117,19 @@ mod tests {
         assert_eq!(diagnostics[0].start, Position::new(2, 3));
         assert_eq!(diagnostics[0].end, Position::new(2, 4));
     }
+
+    #[test]
+    fn check_one_file_reports_prohibited_spacing_without_panicking() {
+        let mut config = Config::default();
+        config.spacing.alphabets = SpacingRule::Prohibit;
+
+        let mut document = Document::new("# 漢 A\n", Grammar::Markdown, Some("t.md"));
+        document.parse().expect("failed to parse the document");
+
+        let diagnostics = check_one_file(&config, &document).expect("failed to check document");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "W002");
+        assert_eq!(diagnostics[0].start, Position::new(0, 3));
+        assert_eq!(diagnostics[0].end, Position::new(0, 4));
+    }
 }

--- a/cjkfmt-cli/src/cli/check.rs
+++ b/cjkfmt-cli/src/cli/check.rs
@@ -45,3 +45,32 @@ where
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::SpacingRule;
+
+    #[test]
+    fn check_command_keeps_markdown_fallback_for_uppercase_json_files() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("document.JSON");
+        fs::write(&path, "漢A\n").unwrap();
+
+        let mut config = Config {
+            max_width: 200,
+            ..Config::default()
+        };
+        config.spacing.alphabets = SpacingRule::Require;
+
+        let mut output = Vec::new();
+        check_command(&mut output, &config, &[&path]).unwrap();
+
+        assert!(
+            String::from_utf8(output).unwrap().contains("W002"),
+            "uppercase .JSON should retain the Markdown grammar fallback"
+        );
+    }
+}

--- a/cjkfmt-cli/src/cli/debug_cst.rs
+++ b/cjkfmt-cli/src/cli/debug_cst.rs
@@ -133,7 +133,23 @@ mod tests {
     }
 
     #[test]
-    fn debug_cst_command_uses_json_grammar_for_json_files() {
+    fn debug_cst_command_uses_markdown_grammar_for_uppercase_json_files() {
+        let path = make_temp_path("JSON");
+        fs::write(&path, "# Test\n").unwrap();
+
+        let mut stdout = Vec::new();
+        let mut stdin = "".as_bytes();
+        debug_cst_command_with_reader(&mut stdout, &[&path], &mut stdin).unwrap();
+
+        let actual = String::from_utf8(stdout).unwrap();
+        assert!(actual.contains("(section [0, 0] - [1, 0]"));
+        assert!(!actual.contains("(object "));
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn debug_cst_command_uses_json_grammar_for_lowercase_json_files() {
         let path = make_temp_path("json");
         fs::write(&path, "{\"name\":1}\n").unwrap();
 

--- a/cjkfmt-cli/src/cli/format.rs
+++ b/cjkfmt-cli/src/cli/format.rs
@@ -11,16 +11,102 @@ pub fn format_command<W: std::io::Write, P: AsRef<Path>>(
     config: &Config,
     filenames: &[P],
 ) -> anyhow::Result<()> {
-    // Read content of the specified files or standard input
+    let mut stdin = stdin();
+    format_command_with_reader(stdout, config, filenames, &mut stdin)
+}
+
+fn is_markdown_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("md") || extension.eq_ignore_ascii_case("markdown")
+        })
+}
+
+fn format_command_with_reader<W, P, R>(
+    stdout: &mut W,
+    config: &Config,
+    filenames: &[P],
+    stdin: &mut R,
+) -> anyhow::Result<()>
+where
+    W: std::io::Write,
+    P: AsRef<Path>,
+    R: Read,
+{
+    // Read content of the specified files or standard input. Without a
+    // filename, the input type is unknown, so Markdown spacing is opt-in
+    // rather than assumed.
     if filenames.is_empty() {
         let mut content = String::with_capacity(1024);
-        stdin().read_to_string(&mut content)?;
-        format_one_file(stdout, config, &content)?;
+        stdin.read_to_string(&mut content)?;
+        format_one_file(stdout, config, false, &content)?;
     } else {
         for filename in filenames {
+            let filename = filename.as_ref();
+            let apply_markdown_spacing = is_markdown_path(filename);
             let content = fs::read_to_string(filename)?;
-            format_one_file(stdout, config, &content)?;
+            format_one_file(stdout, config, apply_markdown_spacing, &content)?;
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::{Config, SpacingRule};
+
+    fn config() -> Config {
+        let mut config = Config {
+            max_width: 200,
+            ..Config::default()
+        };
+        config.spacing.alphabets = SpacingRule::Require;
+        config
+    }
+
+    #[test]
+    fn format_command_applies_spacing_only_to_identified_markdown_files() {
+        let directory = tempdir().unwrap();
+        let cases = [
+            ("document.md", "漢 A\n"),
+            ("document.markdown", "漢 A\n"),
+            ("document.MD", "漢 A\n"),
+            ("document.MarkDown", "漢 A\n"),
+            ("document.txt", "漢A\n"),
+            ("document.rs", "漢A\n"),
+            ("document.JSON", "漢A\n"),
+            ("document", "漢A\n"),
+            ("document.md.txt", "漢A\n"),
+        ];
+        let mut paths = Vec::with_capacity(cases.len());
+        for (filename, _) in cases {
+            let path = directory.path().join(filename);
+            fs::write(&path, "漢A\n").unwrap();
+            paths.push(path);
+        }
+
+        let mut output = Vec::new();
+        format_command(&mut output, &config(), &paths).unwrap();
+
+        let expected: String = cases.iter().map(|(_, output)| *output).collect();
+        assert_eq!(String::from_utf8(output).unwrap(), expected);
+        // `TempDir` removes the directory during unwinding as well as on
+        // success, so assertion failures do not leave test files behind.
+    }
+
+    #[test]
+    fn format_command_does_not_assume_stdin_is_markdown() {
+        let mut input = "漢A\n".as_bytes();
+        let mut output = Vec::new();
+
+        format_command_with_reader(&mut output, &config(), &[] as &[PathBuf], &mut input).unwrap();
+
+        assert_eq!(String::from_utf8(output).unwrap(), "漢A\n");
+    }
 }

--- a/cjkfmt-cli/src/format.rs
+++ b/cjkfmt-cli/src/format.rs
@@ -1,17 +1,23 @@
-use cjkfmt_core::lines_inclusive::LinesInclusiveExt;
-
 use crate::{
     config::Config,
     line_break::{BreakPoint, LineBreaker},
     markdown_spacing::apply_markdown_spacing,
 };
+use cjkfmt_core::lines_inclusive::LinesInclusiveExt;
 
 pub(crate) fn format_one_file<W: std::io::Write>(
     stdout: &mut W,
     config: &Config,
+    apply_spacing: bool,
     content: &str,
 ) -> Result<(), anyhow::Error> {
-    let content = apply_markdown_spacing(config, content)?;
+    // Keep Markdown spacing selection separate from line wrapping. Both
+    // Markdown and non-Markdown inputs retain the existing wrapping pass.
+    let content = if apply_spacing {
+        apply_markdown_spacing(config, content)?
+    } else {
+        content.to_owned()
+    };
 
     let line_breaker = LineBreaker::builder()
         .ambiguous_width(config.ambiguous_width)
@@ -38,4 +44,36 @@ pub(crate) fn format_one_file<W: std::io::Write>(
         write!(stdout, "{remainings}")?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SpacingRule;
+
+    fn config() -> Config {
+        let mut config = Config {
+            max_width: 200,
+            ..Config::default()
+        };
+        config.spacing.alphabets = SpacingRule::Require;
+        config
+    }
+
+    fn format(apply_markdown_spacing: bool, source: &str) -> String {
+        let mut output = Vec::new();
+        format_one_file(&mut output, &config(), apply_markdown_spacing, source).unwrap();
+        String::from_utf8(output).unwrap()
+    }
+
+    #[test]
+    fn format_applies_configured_spacing_to_markdown_prose() {
+        assert_eq!(format(true, "漢A\n"), "漢 A\n");
+    }
+
+    #[test]
+    fn format_preserves_spacing_in_non_markdown_input() {
+        let source = "{\"value\":\"漢A\"}\n";
+        assert_eq!(format(false, source), source);
+    }
 }

--- a/cjkfmt-cli/src/format.rs
+++ b/cjkfmt-cli/src/format.rs
@@ -3,6 +3,7 @@ use cjkfmt_core::lines_inclusive::LinesInclusiveExt;
 use crate::{
     config::Config,
     line_break::{BreakPoint, LineBreaker},
+    markdown_spacing::apply_markdown_spacing,
 };
 
 pub(crate) fn format_one_file<W: std::io::Write>(
@@ -10,6 +11,8 @@ pub(crate) fn format_one_file<W: std::io::Write>(
     config: &Config,
     content: &str,
 ) -> Result<(), anyhow::Error> {
+    let content = apply_markdown_spacing(config, content)?;
+
     let line_breaker = LineBreaker::builder()
         .ambiguous_width(config.ambiguous_width)
         .max_width(config.max_width)

--- a/cjkfmt-cli/src/main.rs
+++ b/cjkfmt-cli/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod document;
 mod format;
 mod line_break;
+mod markdown_spacing;
 mod spacing;
 mod spacing_checker;
 

--- a/cjkfmt-cli/src/main.rs
+++ b/cjkfmt-cli/src/main.rs
@@ -164,7 +164,7 @@ mod file_based_tests {
         let mut actual: Vec<u8> = Vec::with_capacity(1024);
 
         // Run the formatter on the input
-        format_one_file(&mut actual, &test_case.config, &test_case.input)
+        format_one_file(&mut actual, &test_case.config, true, &test_case.input)
             .unwrap_or_else(|_| panic!("failed on formatting a file: {resource:?}"));
 
         // Compare the actual output with the expected output

--- a/cjkfmt-cli/src/markdown_spacing.rs
+++ b/cjkfmt-cli/src/markdown_spacing.rs
@@ -1,0 +1,338 @@
+use std::ops::Range;
+
+use cjkfmt_parser::{Grammar, parse};
+use tree_sitter::Node;
+
+use crate::{
+    config::Config,
+    spacing::{TextEdit, spacing_edits},
+};
+
+const EXCLUDED_NODE_KINDS: &[&str] = &[
+    "code_span",
+    "link_destination",
+    "link_title",
+    "link_label",
+    "uri_autolink",
+    "email_autolink",
+    "html_tag",
+    "latex_block",
+    "entity_reference",
+    "numeric_character_reference",
+    "backslash_escape",
+];
+
+/// Applies configured spacing rules to Markdown prose while preserving inline
+/// constructs whose contents are not displayed as ordinary prose.
+pub(crate) fn apply_markdown_spacing(config: &Config, source: &str) -> anyhow::Result<String> {
+    let block_tree = parse(Grammar::Markdown, source)?;
+    let mut inline_ranges = Vec::new();
+    collect_inline_ranges(block_tree.root_node(), &mut inline_ranges);
+
+    let mut edits = Vec::new();
+    for inline_range in inline_ranges {
+        let inline_source = source
+            .get(inline_range.clone())
+            .ok_or_else(|| anyhow::anyhow!("Markdown inline node has an invalid byte range"))?;
+        let inline_tree = parse(Grammar::MarkdownInline, inline_source)?;
+
+        // Recovery trees can contain misleading prose-looking descendants.
+        // Keeping the whole inline node unchanged is safer than formatting a
+        // malformed construct partially.
+        if inline_tree.root_node().has_error()
+            || !is_safe_inline_tree(inline_tree.root_node(), inline_source)
+        {
+            continue;
+        }
+
+        let mut exclusions = Vec::new();
+        collect_exclusion_ranges(inline_tree.root_node(), &mut exclusions);
+        collect_unrecognized_autolink_ranges(
+            inline_tree.root_node(),
+            inline_source,
+            &mut exclusions,
+        );
+        merge_ranges(&mut exclusions);
+
+        for edit in spacing_edits(config, inline_source) {
+            if !exclusions
+                .iter()
+                .any(|exclusion| edit_intersects(&edit.range, exclusion))
+            {
+                edits.push(TextEdit {
+                    range: (inline_range.start + edit.range.start)
+                        ..(inline_range.start + edit.range.end),
+                    replacement: edit.replacement,
+                });
+            }
+        }
+    }
+
+    apply_text_edits(source, edits)
+}
+
+fn collect_inline_ranges(node: Node<'_>, ranges: &mut Vec<Range<usize>>) {
+    if node.kind() == "inline" {
+        ranges.push(node.byte_range());
+        // Do not collect an inline descendant if a future grammar revision
+        // happens to nest one: each source slice is parsed exactly once.
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_inline_ranges(child, ranges);
+    }
+}
+
+fn is_safe_inline_tree(root: Node<'_>, source: &str) -> bool {
+    // The pinned grammar recovers some malformed input without setting its
+    // ERROR flag (for example, an unclosed code span becomes an empty inline
+    // node). Do not reinterpret syntax-looking recovery text as prose.
+    let backtick_count = source.chars().filter(|&character| character == '`').count();
+    if backtick_count > 0 && (backtick_count % 2 == 1 || !has_node_kind(root, "code_span")) {
+        return false;
+    }
+    let dollar_count = source.chars().filter(|&character| character == '$').count();
+    if dollar_count % 2 == 1 {
+        return false;
+    }
+    if source.contains("](") && !has_node_kind(root, "inline_link") && !has_node_kind(root, "image")
+    {
+        return false;
+    }
+    true
+}
+
+fn collect_unrecognized_autolink_ranges(
+    root: Node<'_>,
+    source: &str,
+    ranges: &mut Vec<Range<usize>>,
+) {
+    let mut search_start = 0;
+    while let Some(relative_start) = source[search_start..].find('<') {
+        let start = search_start + relative_start;
+        let Some(relative_end) = source[start + 1..].find('>') else {
+            break;
+        };
+        let end = start + 1 + relative_end + 1;
+        let candidate = &source[start..end];
+        if (candidate.contains('@') || candidate.contains("://"))
+            && !has_exclusion_covering(root, start..end)
+        {
+            ranges.push(start..end);
+        }
+        search_start = end;
+    }
+}
+
+fn has_exclusion_covering(node: Node<'_>, range: Range<usize>) -> bool {
+    if EXCLUDED_NODE_KINDS.contains(&node.kind()) {
+        let node_range = node.byte_range();
+        if node_range.start <= range.start && range.end <= node_range.end {
+            return true;
+        }
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| has_exclusion_covering(child, range.clone()))
+}
+
+fn has_node_kind(node: Node<'_>, kind: &str) -> bool {
+    if node.kind() == kind {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| has_node_kind(child, kind))
+}
+
+fn collect_exclusion_ranges(node: Node<'_>, ranges: &mut Vec<Range<usize>>) {
+    if EXCLUDED_NODE_KINDS.contains(&node.kind()) {
+        ranges.push(node.byte_range());
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_exclusion_ranges(child, ranges);
+    }
+}
+
+fn merge_ranges(ranges: &mut Vec<Range<usize>>) {
+    ranges.sort_by_key(|range| (range.start, range.end));
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+    for range in ranges.drain(..) {
+        if let Some(last) = merged.last_mut()
+            && range.start <= last.end
+        {
+            last.end = last.end.max(range.end);
+        } else {
+            merged.push(range);
+        }
+    }
+    *ranges = merged;
+}
+
+fn edit_intersects(edit: &Range<usize>, exclusion: &Range<usize>) -> bool {
+    if edit.is_empty() {
+        exclusion.start <= edit.start && edit.start < exclusion.end
+    } else {
+        edit.start < exclusion.end && exclusion.start < edit.end
+    }
+}
+
+fn apply_text_edits(source: &str, mut edits: Vec<TextEdit>) -> anyhow::Result<String> {
+    edits.sort_by_key(|edit| (edit.range.start, edit.range.end));
+    for edit in &edits {
+        if edit.range.start > edit.range.end
+            || edit.range.end > source.len()
+            || !source.is_char_boundary(edit.range.start)
+            || !source.is_char_boundary(edit.range.end)
+        {
+            anyhow::bail!("spacing edit is not a valid UTF-8 range: {:?}", edit.range);
+        }
+    }
+
+    for pair in edits.windows(2) {
+        let previous = &pair[0].range;
+        let current = &pair[1].range;
+        if previous.end > current.start
+            || (previous.is_empty() && current.is_empty() && previous.start == current.start)
+            || (previous.start == current.start && (!previous.is_empty() || !current.is_empty()))
+        {
+            anyhow::bail!(
+                "overlapping spacing edits: {:?} and {:?}",
+                previous,
+                current
+            );
+        }
+    }
+
+    if edits.is_empty() {
+        return Ok(source.to_string());
+    }
+
+    let mut formatted = source.to_string();
+    for edit in edits.into_iter().rev() {
+        formatted.replace_range(edit.range, &edit.replacement);
+    }
+    Ok(formatted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SpacingRule;
+
+    fn config(alphabets: SpacingRule, digits: SpacingRule) -> Config {
+        let mut config = Config {
+            max_width: 200,
+            ..Config::default()
+        };
+        config.spacing.alphabets = alphabets;
+        config.spacing.digits = digits;
+        config
+    }
+
+    fn format(source: &str, alphabets: SpacingRule, digits: SpacingRule) -> String {
+        apply_markdown_spacing(&config(alphabets, digits), source).unwrap()
+    }
+
+    #[test]
+    fn formats_prose_inside_inline_markdown_constructs() {
+        assert_eq!(
+            format(
+                "*漢A* **漢1** ~~A漢~~",
+                SpacingRule::Require,
+                SpacingRule::Require
+            ),
+            "*漢 A* **漢 1** ~~A 漢~~"
+        );
+    }
+
+    #[test]
+    fn formats_link_text_and_image_description_but_not_destinations() {
+        let source = "[漢A](https://example.test/漢A) ![漢A](image漢A.png)";
+        assert_eq!(
+            format(source, SpacingRule::Require, SpacingRule::Ignore),
+            "[漢 A](https://example.test/漢A) ![漢 A](image漢A.png)"
+        );
+    }
+
+    #[test]
+    fn preserves_non_prose_inline_ranges() {
+        let source = concat!(
+            "`漢A` ``漢1`` <https://example.test/漢A> <foo@example.test> ",
+            "<漢A@example.test> <a href=\"漢A\"> $漢A$ &amp;漢A \\*漢A\n",
+        );
+        assert_eq!(
+            format(source, SpacingRule::Require, SpacingRule::Require),
+            concat!(
+                "`漢A` ``漢1`` <https://example.test/漢A> <foo@example.test> ",
+                "<漢A@example.test> <a href=\"漢A\"> $漢A$ &amp;漢 A \\*漢 A\n",
+            )
+        );
+    }
+
+    #[test]
+    fn reference_link_label_is_not_formatted() {
+        assert_eq!(
+            format("[漢A][漢A]", SpacingRule::Require, SpacingRule::Ignore),
+            "[漢 A][漢A]"
+        );
+    }
+
+    #[test]
+    fn preserves_fenced_code_and_formats_other_inline_nodes() {
+        let source = "漢A\n\n```rust 漢A\n漢A\n```\n\n漢A\n";
+        assert_eq!(
+            format(source, SpacingRule::Require, SpacingRule::Ignore),
+            "漢 A\n\n```rust 漢A\n漢A\n```\n\n漢 A\n"
+        );
+    }
+
+    #[test]
+    fn applies_many_document_edits_using_original_offsets() {
+        let source = "漢A\n漢A\n漢A";
+        assert_eq!(
+            format(source, SpacingRule::Require, SpacingRule::Ignore),
+            "漢 A\n漢 A\n漢 A"
+        );
+    }
+
+    #[test]
+    fn prohibit_removes_only_ascii_spaces_in_prose() {
+        assert_eq!(
+            format("漢  A `漢  A`", SpacingRule::Prohibit, SpacingRule::Ignore),
+            "漢A `漢  A`"
+        );
+    }
+
+    #[test]
+    fn malformed_inline_recovery_is_kept_unchanged() {
+        for source in ["[漢A](<broken\n漢A>)", "[漢A](broken", "`漢A", "``漢A`"] {
+            assert_eq!(
+                format(source, SpacingRule::Require, SpacingRule::Ignore),
+                source,
+                "malformed inline source was changed: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validates_and_applies_edits_in_reverse_order() {
+        let source = "漢A漢A";
+        let edits = vec![
+            TextEdit {
+                range: 3..3,
+                replacement: " ".to_string(),
+            },
+            TextEdit {
+                range: 7..7,
+                replacement: " ".to_string(),
+            },
+        ];
+        assert_eq!(apply_text_edits(source, edits).unwrap(), "漢 A漢 A");
+    }
+}

--- a/cjkfmt-cli/src/spacing.rs
+++ b/cjkfmt-cli/src/spacing.rs
@@ -1,9 +1,14 @@
+use std::{ops::Range, str::CharIndices};
+
 use unicode_general_category::{GeneralCategory, get_general_category};
 
-use crate::{
-    _log::test_log,
-    config::{Config, SpacingRule},
-};
+use crate::config::{Config, SpacingRule};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TextEdit {
+    pub(crate) range: Range<usize>,
+    pub(crate) replacement: String,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum CharType {
@@ -14,59 +19,133 @@ enum CharType {
     Other,
 }
 
-/// Enum representing possible edits for spacing.
-#[allow(dead_code)] // TODO: Use Delete variant
-enum SpaceEdit {
-    Add,
-    Delete,
-}
+/// Returns the spacing edits needed for a piece of text.
+///
+/// The ranges are UTF-8 byte ranges relative to `text`. Markdown syntax is
+/// intentionally not considered here; callers that understand a syntax tree
+/// filter these edits before applying them.
+pub(crate) fn spacing_edits(config: &Config, text: &str) -> Vec<TextEdit> {
+    let characters = text_characters(text);
+    let mut edits = Vec::new();
 
-pub fn search_possible_spacing_positions(config: &Config, text: &str) -> Vec<usize> {
-    let mut indices = Vec::new();
+    for pair in characters.windows(2) {
+        let [previous, current] = pair else {
+            unreachable!();
+        };
 
-    // Scan the text character by character to find possible position to insert a space.
-    let mut char_iterator = text.char_indices();
-    let Some(mut prev_type) = char_iterator.next().map(|(_, c)| char_type(c)) else {
-        return indices;
-    };
-    for (index, curr_char) in char_iterator {
-        // Check if this is a candidate position to insert a space
-        let curr_type = char_type(curr_char);
-        match evaluate_spacing(config, prev_type, curr_type) {
-            Some(SpaceEdit::Add) => indices.push(index),
-            Some(SpaceEdit::Delete) => todo!(),
-            None => (),
+        match (previous.kind, current.kind) {
+            pair if is_spacing_pair(pair.0, pair.1)
+                && spacing_rule(config, pair.0, pair.1) == SpacingRule::Require =>
+            {
+                edits.push(TextEdit {
+                    range: current.start..current.start,
+                    replacement: " ".to_string(),
+                });
+            }
+            _ => {}
         }
-        test_log!("{text:?}[{index:2}] --> {curr_char:?} ({prev_type:?}, {curr_type:?})");
-
-        // Update the previous character type
-        prev_type = curr_type;
     }
 
-    indices
+    // A run of ASCII spaces is handled as one edit. In particular, do not
+    // treat tabs or line endings as part of a deletable run.
+    let mut index = 0;
+    while index < characters.len() {
+        if characters[index].character != ' ' {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        while index < characters.len() && characters[index].character == ' ' {
+            index += 1;
+        }
+        let end = index;
+        if start == 0 || end == characters.len() {
+            continue;
+        }
+
+        let left = characters[start - 1];
+        let right = characters[end];
+        if is_spacing_pair(left.kind, right.kind)
+            && spacing_rule(config, left.kind, right.kind) == SpacingRule::Prohibit
+        {
+            edits.push(TextEdit {
+                range: left.end..right.start,
+                replacement: String::new(),
+            });
+        }
+    }
+
+    edits
 }
 
-fn evaluate_spacing(config: &Config, prev: CharType, curr: CharType) -> Option<SpaceEdit> {
-    match (prev, curr) {
+/// Compatibility helper for the checker’s historical insertion-only API.
+#[allow(dead_code)]
+pub(crate) fn search_possible_spacing_positions(config: &Config, text: &str) -> Vec<usize> {
+    spacing_edits(config, text)
+        .into_iter()
+        .filter(|edit| edit.range.is_empty() && edit.replacement == " ")
+        .map(|edit| edit.range.start)
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TextCharacter {
+    start: usize,
+    end: usize,
+    character: char,
+    kind: CharType,
+}
+
+fn text_characters(text: &str) -> Vec<TextCharacter> {
+    let mut characters = Vec::new();
+    let mut indices: CharIndices<'_> = text.char_indices();
+    while let Some((start, character)) = indices.next() {
+        let end = indices
+            .clone()
+            .next()
+            .map_or(text.len(), |(index, _)| index);
+        characters.push(TextCharacter {
+            start,
+            end,
+            character,
+            kind: char_type(character),
+        });
+    }
+    characters
+}
+
+fn is_spacing_pair(left: CharType, right: CharType) -> bool {
+    matches!(
+        (left, right),
+        (CharType::Cjk, CharType::Digit)
+            | (CharType::Digit, CharType::Cjk)
+            | (CharType::Cjk, CharType::Latin)
+            | (CharType::Latin, CharType::Cjk)
+    )
+}
+
+fn spacing_rule(config: &Config, left: CharType, right: CharType) -> SpacingRule {
+    match (left, right) {
         (CharType::Cjk, CharType::Digit) | (CharType::Digit, CharType::Cjk) => {
-            match config.spacing.digits {
-                SpacingRule::Require => Some(SpaceEdit::Add),
-                SpacingRule::Prohibit => todo!(),
-                SpacingRule::Ignore => None,
-            }
+            config.spacing.digits
         }
         (CharType::Cjk, CharType::Latin) | (CharType::Latin, CharType::Cjk) => {
-            match config.spacing.alphabets {
-                SpacingRule::Require => Some(SpaceEdit::Add),
-                SpacingRule::Prohibit => todo!(),
-                SpacingRule::Ignore => None,
-            }
+            config.spacing.alphabets
         }
-        _ => None,
+        _ => SpacingRule::Ignore,
     }
 }
 
 fn char_type(c: char) -> CharType {
+    // Only ASCII spaces are editable. Other whitespace must also prevent a
+    // spacing pair from spanning it, including U+3000 in the broad CJK range.
+    match c {
+        ' ' | '\r' | '\n' => return CharType::Space,
+        _ if c.is_whitespace() => return CharType::Other,
+        _ => {}
+    }
+
     // TODO: Refine the character set by reviewing https://www.unicode.org/charts/
     match c {
         // CJK Unified Ideographs
@@ -100,25 +179,20 @@ fn char_type(c: char) -> CharType {
         // Bopomofo: U+3100–U+312F
         | '\u{3100}'..='\u{312F}'
         // Hangul Syllables: U+AC00–U+D7AF
-        | '\u{AC00}'..='\u{D7AF}'
-        => {
-             match get_general_category(c) {
-                 // Exclude punctuation charactersØ
-                GeneralCategory::ClosePunctuation
-                | GeneralCategory::ConnectorPunctuation
-                | GeneralCategory::DashPunctuation
-                | GeneralCategory::FinalPunctuation
-                | GeneralCategory::InitialPunctuation
-                | GeneralCategory::OpenPunctuation
-                | GeneralCategory::OtherPunctuation
-                => CharType::Other,
-                _ => CharType::Cjk,
-            }
+        | '\u{AC00}'..='\u{D7AF}' => match get_general_category(c) {
+            // Exclude punctuation characters.
+            GeneralCategory::ClosePunctuation
+            | GeneralCategory::ConnectorPunctuation
+            | GeneralCategory::DashPunctuation
+            | GeneralCategory::FinalPunctuation
+            | GeneralCategory::InitialPunctuation
+            | GeneralCategory::OpenPunctuation
+            | GeneralCategory::OtherPunctuation => CharType::Other,
+            _ => CharType::Cjk,
         },
 
-        // Basic Latin : Uppercase letters
+        // Basic Latin : Uppercase and lowercase letters
         'A'..='Z'
-        // Basic Latin : Lowercase letters
         | 'a'..='z'
         // Latin-1 Supplement
         | '\u{00C0}'..='\u{00FF}'
@@ -147,16 +221,11 @@ fn char_type(c: char) -> CharType {
         // Latin Extended-F
         | '\u{10780}'..='\u{107BF}'
         // Latin Extended-G
-        | '\u{1DF00}'..='\u{1DFFF}'
-        => CharType::Latin, // Basic Latin
+        | '\u{1DF00}'..='\u{1DFFF}' => CharType::Latin,
 
         // Half-width digits
         '0'..='9' => CharType::Digit,
 
-        // Whitespace characters
-        ' ' | '\r' | '\n' => CharType::Space,
-
-        // Other characters
         _ => CharType::Other,
     }
 }
@@ -165,12 +234,78 @@ fn char_type(c: char) -> CharType {
 mod tests {
     use super::*;
 
+    fn make_config(alphabets: SpacingRule, digits: SpacingRule) -> Config {
+        let mut config = Config::default();
+        config.spacing.alphabets = alphabets;
+        config.spacing.digits = digits;
+        config
+    }
+
+    fn edits(config: &Config, text: &str) -> Vec<(Range<usize>, String)> {
+        spacing_edits(config, text)
+            .into_iter()
+            .map(|edit| (edit.range, edit.replacement))
+            .collect()
+    }
+
     #[test]
-    fn test_char_type() {
-        assert!(char_type('中') == CharType::Cjk);
-        assert!(char_type('漢') == CharType::Cjk);
-        assert!(char_type('a') == CharType::Latin);
-        assert!(char_type('1') == CharType::Digit);
-        assert!(char_type(' ') == CharType::Space);
+    fn require_inserts_at_utf8_byte_boundaries_in_both_directions() {
+        let config = make_config(SpacingRule::Require, SpacingRule::Require);
+        assert_eq!(
+            edits(&config, "漢A1漢"),
+            vec![(3..3, " ".to_string()), (5..5, " ".to_string())]
+        );
+    }
+
+    #[test]
+    fn require_does_not_duplicate_existing_ascii_space() {
+        let config = make_config(SpacingRule::Require, SpacingRule::Require);
+        assert!(spacing_edits(&config, "漢 A").is_empty());
+    }
+
+    #[test]
+    fn prohibit_deletes_a_complete_ascii_space_run() {
+        let config = make_config(SpacingRule::Prohibit, SpacingRule::Prohibit);
+        assert_eq!(edits(&config, "漢   A  1"), vec![(3..6, String::new())]);
+    }
+
+    #[test]
+    fn prohibit_does_not_cross_non_ascii_space_or_line_endings() {
+        let config = make_config(SpacingRule::Prohibit, SpacingRule::Prohibit);
+        for text in ["漢\tA", "漢\nA", "漢\r\nA", "漢\u{00a0}A", "漢\u{3000}A"] {
+            assert!(spacing_edits(&config, text).is_empty(), "changed {text:?}");
+        }
+    }
+
+    #[test]
+    fn alphabet_and_digit_rules_are_independent() {
+        let config = make_config(SpacingRule::Require, SpacingRule::Ignore);
+        assert_eq!(
+            edits(&config, "漢A漢1"),
+            vec![(3..3, " ".to_string()), (4..4, " ".to_string())]
+        );
+
+        let digit_config = make_config(SpacingRule::Ignore, SpacingRule::Prohibit);
+        assert_eq!(
+            edits(&digit_config, "漢 A 漢  1"),
+            vec![(9..11, String::new())]
+        );
+    }
+
+    #[test]
+    fn ignore_leaves_both_kinds_unchanged() {
+        let config = make_config(SpacingRule::Ignore, SpacingRule::Ignore);
+        assert!(spacing_edits(&config, "漢A 漢 1").is_empty());
+    }
+
+    #[test]
+    fn character_types_keep_punctuation_out_of_spacing_pairs() {
+        assert_eq!(char_type('中'), CharType::Cjk);
+        assert_eq!(char_type('漢'), CharType::Cjk);
+        assert_eq!(char_type('a'), CharType::Latin);
+        assert_eq!(char_type('1'), CharType::Digit);
+        assert_eq!(char_type(' '), CharType::Space);
+        assert_eq!(char_type('。'), CharType::Other);
+        assert_eq!(char_type('\u{3000}'), CharType::Other);
     }
 }

--- a/cjkfmt-cli/src/spacing.rs
+++ b/cjkfmt-cli/src/spacing.rs
@@ -79,16 +79,6 @@ pub(crate) fn spacing_edits(config: &Config, text: &str) -> Vec<TextEdit> {
     edits
 }
 
-/// Compatibility helper for the checker’s historical insertion-only API.
-#[allow(dead_code)]
-pub(crate) fn search_possible_spacing_positions(config: &Config, text: &str) -> Vec<usize> {
-    spacing_edits(config, text)
-        .into_iter()
-        .filter(|edit| edit.range.is_empty() && edit.replacement == " ")
-        .map(|edit| edit.range.start)
-        .collect()
-}
-
 #[derive(Debug, Clone, Copy)]
 struct TextCharacter {
     start: usize,

--- a/cjkfmt-cli/src/spacing_checker.rs
+++ b/cjkfmt-cli/src/spacing_checker.rs
@@ -2,7 +2,11 @@ use cjkfmt_core::{diagnostic::Diagnostic, position::Position};
 use cjkfmt_parser::NodeVisitor;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{config::Config, document::Document, spacing::search_possible_spacing_positions};
+use crate::{
+    config::Config,
+    document::Document,
+    spacing::{TextEdit, spacing_edits},
+};
 
 /// Checks for possible spacing issues in a document by traversing its parse tree.
 #[derive(Debug)]
@@ -37,40 +41,56 @@ impl<'a> NodeVisitor for SpacingChecker<'a> {
             let range_start = range.start;
             let text = &self.document.content[range];
 
-            // Search for possible spacing positions and store them as diagnostics
-            for i in search_possible_spacing_positions(self.config, text) {
-                let absolute_index = range_start + i;
-                let text_before = &self.document.content[..absolute_index];
-                let line_index = text_before.chars().filter(|&c| c == '\n').count() as u32;
-                let line_start = text_before
-                    .rsplit_once('\n')
-                    .map(|(_, line)| line)
-                    .unwrap_or(text_before);
-
-                // Calculate number of characters from the beginning of the line
-                let column_index = line_start.graphemes(true).fold(0u32, |acc, s| {
-                    acc + s.encode_utf16().fold(0u32, |acc, _| acc + 1)
-                });
-
-                // Get number of Unicode scalar values of the next character
-                let next_char_len = text[i..]
-                    .graphemes(true)
-                    .next()
-                    .map(|s| s.encode_utf16().fold(0u32, |acc, _| acc + 1))
-                    .unwrap_or(0u32);
-
-                let d = Diagnostic::new(
-                    self.document.filename.as_deref(),
-                    Position::new(line_index, column_index),
-                    Position::new(line_index, column_index + next_char_len),
-                    "W002".to_string(),
-                    "Possible spacing position found".to_string(),
-                );
-                self.diagnostics.push(d);
+            // Convert the shared spacing edits into diagnostics. The checker
+            // deliberately retains its existing block-inline scope; Markdown
+            // prose filtering belongs to the formatter's Markdown module.
+            for edit in spacing_edits(self.config, text) {
+                let absolute_start = range_start + edit.range.start;
+                let absolute_end = range_start + edit.range.end;
+                let diagnostic = self.diagnostic_for_edit(&edit, absolute_start, absolute_end);
+                self.diagnostics.push(diagnostic);
             }
         }
     }
 
     /// Called when exiting a node in the parse tree. No action needed here.
     fn on_exit(&mut self, _node: &tree_sitter::Node) {}
+}
+
+impl<'a> SpacingChecker<'a> {
+    fn diagnostic_for_edit(
+        &self,
+        edit: &TextEdit,
+        absolute_start: usize,
+        absolute_end: usize,
+    ) -> Diagnostic {
+        let text_before = &self.document.content[..absolute_start];
+        let line_index = text_before.chars().filter(|&c| c == '\n').count() as u32;
+        let line_start = text_before
+            .rsplit_once('\n')
+            .map(|(_, line)| line)
+            .unwrap_or(text_before);
+        let column_index = utf16_len(line_start);
+
+        let end_column = if edit.range.is_empty() {
+            self.document.content[absolute_start..]
+                .graphemes(true)
+                .next()
+                .map_or(column_index, |grapheme| column_index + utf16_len(grapheme))
+        } else {
+            column_index + utf16_len(&self.document.content[absolute_start..absolute_end])
+        };
+
+        Diagnostic::new(
+            self.document.filename.as_deref(),
+            Position::new(line_index, column_index),
+            Position::new(line_index, end_column),
+            "W002".to_string(),
+            "Possible spacing position found".to_string(),
+        )
+    }
+}
+
+fn utf16_len(text: &str) -> u32 {
+    text.encode_utf16().count() as u32
 }

--- a/cjkfmt-parser/src/ffi.rs
+++ b/cjkfmt-parser/src/ffi.rs
@@ -3,4 +3,5 @@ use tree_sitter::Language;
 unsafe extern "C" {
     pub fn tree_sitter_json() -> Language;
     pub fn tree_sitter_markdown() -> Language;
+    pub fn tree_sitter_markdown_inline() -> Language;
 }

--- a/cjkfmt-parser/src/grammar.rs
+++ b/cjkfmt-parser/src/grammar.rs
@@ -9,10 +9,40 @@ pub enum Grammar {
 }
 
 /// Infers the grammar type from the file extension of the given path.
+///
+/// Only an exact lowercase `.json` extension selects JSON. All other paths
+/// retain the historical Markdown fallback used by the CLI commands.
 pub fn grammar_from_path<P: AsRef<Path>>(path: P) -> Grammar {
     let path = path.as_ref();
     match path.extension().map(|s| s.to_str().unwrap()) {
         Some("json") => Grammar::Json,
         _ => Grammar::Markdown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_json_only_for_an_exact_lowercase_extension() {
+        assert_eq!(grammar_from_path("config.json"), Grammar::Json);
+        assert_eq!(grammar_from_path("config.JSON"), Grammar::Markdown);
+    }
+
+    #[test]
+    fn falls_back_to_markdown_for_all_other_paths() {
+        for path in [
+            "README.md",
+            "guide.markdown",
+            "README.MD",
+            "guide.MarkDown",
+            "notes.txt",
+            "main.rs",
+            "README",
+            "README.md.txt",
+        ] {
+            assert_eq!(grammar_from_path(path), Grammar::Markdown, "{path}");
+        }
     }
 }

--- a/cjkfmt-parser/src/grammar.rs
+++ b/cjkfmt-parser/src/grammar.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 pub enum Grammar {
     Json,
     Markdown,
+    MarkdownInline,
 }
 
 /// Infers the grammar type from the file extension of the given path.

--- a/cjkfmt-parser/src/parse.rs
+++ b/cjkfmt-parser/src/parse.rs
@@ -2,7 +2,7 @@ use tree_sitter::{Parser, Tree};
 
 use crate::Grammar;
 use crate::errors::CjkfmtParseError;
-use crate::ffi::{tree_sitter_json, tree_sitter_markdown};
+use crate::ffi::{tree_sitter_json, tree_sitter_markdown, tree_sitter_markdown_inline};
 
 /// Parses the given content string using the specified grammar and returns a syntax tree.
 pub fn parse(grammar: Grammar, content: &str) -> Result<Tree, CjkfmtParseError> {
@@ -11,6 +11,7 @@ pub fn parse(grammar: Grammar, content: &str) -> Result<Tree, CjkfmtParseError> 
         match grammar {
             Grammar::Json => tree_sitter_json(),
             Grammar::Markdown => tree_sitter_markdown(),
+            Grammar::MarkdownInline => tree_sitter_markdown_inline(),
         }
     };
 
@@ -22,4 +23,43 @@ pub fn parse(grammar: Grammar, content: &str) -> Result<Tree, CjkfmtParseError> 
         .ok_or_else(|| CjkfmtParseError::ParseError("failed to parse".to_string()))?;
 
     Ok(tree)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_inline_grammar_parses_plain_text() {
+        let tree = parse(Grammar::MarkdownInline, "漢A").unwrap();
+        assert_eq!(tree.root_node().kind(), "inline");
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn markdown_inline_grammar_exposes_code_span() {
+        let tree = parse(Grammar::MarkdownInline, "`漢A`").unwrap();
+        let root = tree.root_node();
+        let code_span = root.named_child(0).expect("code span should be named");
+        assert_eq!(code_span.kind(), "code_span");
+        assert_eq!(code_span.byte_range(), 0..6);
+    }
+
+    #[test]
+    fn markdown_inline_grammar_exposes_link_text_and_destination() {
+        let source = "[漢A](https://example.test/漢A)";
+        let tree = parse(Grammar::MarkdownInline, source).unwrap();
+        let link = tree
+            .root_node()
+            .named_child(0)
+            .expect("link should be named");
+        assert_eq!(link.kind(), "inline_link");
+
+        let child_kinds: Vec<_> = (0..link.named_child_count() as u32)
+            .map(|index| link.named_child(index).unwrap().kind())
+            .collect();
+        assert_eq!(child_kinds, ["link_text", "link_destination"]);
+        assert_eq!(link.named_child(0).unwrap().byte_range(), 1..5);
+        assert_eq!(link.named_child(1).unwrap().byte_range(), 7..32);
+    }
 }

--- a/docs/design/spacing.md
+++ b/docs/design/spacing.md
@@ -1,0 +1,173 @@
+---
+created: 2028-08-16
+---
+
+# CJK/ASCII Spacing Specification
+
+This specification defines how cjkfmt handles ASCII spacing between CJK characters, Latin
+characters, and digits. It defines observable behavior rather than a particular parser, data
+structure, or edit-application strategy.
+
+The terms **CJK**, **Latin**, and **Digit** in this document are cjkfmt categories. They are not
+synonyms for Unicode Script or East Asian Width properties.
+
+## Scope
+
+This specification covers the following behavior:
+
+- classifying Unicode scalar values into cjkfmt character categories;
+- deciding whether ASCII spaces are required, prohibited, or ignored between adjacent categories;
+- applying those rules to Markdown prose; and
+- reporting the same Markdown prose violations through `check` that `format` can correct.
+
+It does not define general whitespace normalization, spacing between Latin characters and digits,
+or spacing behavior for source-code languages and other document formats.
+
+## Character categories
+
+Each Unicode scalar value belongs to exactly one of the following categories. Classification is
+per scalar value, not per grapheme cluster.
+
+### CJK
+
+A scalar value in one of these candidate ranges is CJK unless its Unicode General Category is one
+of the punctuation categories `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`. Punctuation in a
+candidate range is Other instead.
+
+| Block | Unicode range |
+| --- | --- |
+| CJK Unified Ideographs | U+4E00–U+9FFF |
+| CJK Unified Ideographs Extension A | U+3400–U+4DBF |
+| Extension B | U+20000–U+2A6DF |
+| Extension C | U+2A700–U+2B73F |
+| Extension D | U+2B740–U+2B81F |
+| Extension E | U+2B820–U+2CEAF |
+| Extension F | U+2CEB0–U+2EBEF |
+| Extension G | U+30000–U+3134F |
+| Extension H | U+31350–U+323AF |
+| Extension I | U+2EBF0–U+2EE5D |
+| CJK Radicals Supplement | U+2E80–U+2EFF |
+| CJK Symbols and Punctuation | U+3000–U+303F |
+| Hiragana | U+3040–U+309F |
+| Katakana | U+30A0–U+30FF |
+| Bopomofo | U+3100–U+312F |
+| Hangul Syllables | U+AC00–U+D7AF |
+
+For example, `漢`, `あ`, `ア`, `ㄅ`, and `가` are CJK. `。`, `《`, `》`, and `・` are Other because
+they are punctuation. CJK-related blocks absent from this table, such as CJK Compatibility
+Ideographs, Hangul Jamo, and Halfwidth and Fullwidth Forms, are not CJK.
+
+### Latin
+
+The following ranges are Latin. This is a range-based category rather than a Unicode Script test.
+No General Category exception applies to these ranges.
+
+| Block | Unicode range |
+| --- | --- |
+| Basic Latin uppercase and lowercase letters only | U+0041–U+005A, U+0061–U+007A |
+| Latin-1 Supplement | U+00C0–U+00FF |
+| Latin Extended-A / B / Additional | U+0100–U+017F, U+0180–U+024F, U+1E00–U+1EFF |
+| IPA Extensions | U+0250–U+02AF |
+| Spacing Modifier Letters | U+02B0–U+02FF |
+| Combining Diacritical Marks | U+0300–U+036F |
+| Combining Diacritical Marks Extended / Supplement | U+1AB0–U+1AFF, U+1DC0–U+1DFF |
+| Latin Extended-C / D / E | U+2C60–U+2C7F, U+A720–U+A7FF, U+AB30–U+AB6F |
+| Latin Extended-F / G | U+10780–U+107BF, U+1DF00–U+1DFFF |
+
+Consequently, ASCII punctuation is not Latin, while `×` and `÷` are Latin because they are in the
+Latin-1 Supplement range. Combining marks in the listed ranges are also Latin and are classified
+independently of their surrounding scalar values.
+
+### Digit
+
+Digit consists only of U+0030–U+0039, the ASCII characters `0`–`9`. Full-width digits `０`–`９`,
+CJK numerals, and other Unicode decimal digits are not Digit.
+
+### Whitespace
+
+U+0020 SPACE, U+000D CR, and U+000A LF are spacing boundaries. They are not eligible members of a
+spacing pair. Of those values, only U+0020 is editable by this specification.
+
+All other Unicode whitespace is Other. This includes TAB, U+00A0 NO-BREAK SPACE, and U+3000
+IDEOGRAPHIC SPACE. U+3000 is therefore Other despite also appearing in the CJK Symbols and
+Punctuation candidate range.
+
+### Other
+
+Every scalar value not classified above is Other. Examples include ASCII punctuation and symbols,
+full-width Latin letters such as `Ａ`, full-width digits such as `１`, half-width Katakana, emoji,
+and CJK-related blocks not listed under CJK. Other is never an eligible member of a spacing pair.
+
+## Spacing rules
+
+The only eligible pairs are CJK–Latin and CJK–Digit, in either direction. The corresponding
+configuration settings are independent.
+
+| Pair, in either order | Configuration setting |
+| --- | --- |
+| CJK — Latin | `spacing.alphabets` |
+| CJK — Digit | `spacing.digits` |
+
+All other pairs, including Latin–Digit and CJK–CJK, are ignored.
+
+| Rule | Required behavior |
+| --- | --- |
+| `require` | Insert one U+0020 SPACE when the eligible pair is directly adjacent. |
+| `prohibit` | Delete a nonempty contiguous run of U+0020 SPACE between an eligible pair. |
+| `ignore` | Do not change spacing. |
+
+An existing U+0020 interrupts direct adjacency. Therefore, `require` does not normalize spacing:
+it leaves both `漢 A` and `漢   A` unchanged. `prohibit` removes all ASCII spaces in an eligible
+run, but it does not remove or cross a tab, line ending, full-width space, no-break space, or any
+other non-ASCII whitespace.
+
+| Input | `require` | `prohibit` |
+| --- | --- | --- |
+| `漢A` | `漢 A` | unchanged |
+| `A漢` | `A 漢` | unchanged |
+| `漢 1` | unchanged | `漢1` |
+| `漢   A` | unchanged | `漢A` |
+| `漢\tA` | unchanged | unchanged |
+| `漢Ａ` | unchanged | unchanged |
+| `漢。A` | unchanged | unchanged |
+
+## Markdown prose
+
+For Markdown documents, spacing rules apply to visible prose. This includes ordinary text,
+emphasis, strikethrough, link text, and image descriptions.
+
+Spacing rules do not modify or diagnose the following non-prose content:
+
+- inline code and fenced code blocks;
+- link destinations, titles, and reference labels;
+- autolink URLs and email addresses;
+- HTML tags;
+- entity and numeric character references;
+- backslash-escaped syntax; and
+- malformed or otherwise unsafe inline constructs.
+
+When Markdown cannot be interpreted safely, cjkfmt must preserve the affected construct rather
+than partially formatting or diagnosing its contents.
+
+## Checking and formatting
+
+For the same Markdown input and configuration, `check` and `format` must select the same prose
+content and apply the same spacing rules.
+
+- `check` must report a spacing diagnostic exactly where `format` would make a spacing change.
+- `format` must make every spacing change reported by `check` when run with the same configuration.
+- Neither command may act on content excluded by the Markdown prose rules above.
+
+This is the intended contract. The current checker does not yet share all of the formatter's
+Markdown prose selection rules; the conformance gap is tracked in [issue #91].
+
+[issue #91]: https://github.com/sgryjp/cjkfmt/issues/91
+
+## Non-goals
+
+This specification does not require cjkfmt to:
+
+- normalize arbitrary whitespace or convert one whitespace character to another;
+- insert or remove spaces for Latin–Digit, CJK–CJK, or other ineligible pairs;
+- treat all Unicode decimal digits as Digit; or
+- apply Markdown prose rules to non-Markdown documents.


### PR DESCRIPTION
## Summary

- apply configured CJK/ASCII spacing rules when formatting Markdown prose
- preserve code and other non-prose Markdown content while leaving non-Markdown spacing untouched
- share range-based spacing edits between formatting and diagnostics
- document the formatter behavior and add regression coverage for grammar dispatch

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace`
- `cargo test --all-features --workspace`

Closes #5